### PR TITLE
isHomePage now set as true by indexRoute

### DIFF
--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -6,7 +6,7 @@ import Menu from '../Menu'
 import Links from '../Links'
 import './style.scss'
 
-const sidebar = () => {
+const sidebar = ({ isHomePage }) => {
   const data = useStaticQuery(graphql`
   query SidebarQuery {
     kontentItemSiteMetadata(system: {codename: {eq: "site_metadata"}}) {
@@ -81,7 +81,6 @@ const sidebar = () => {
   const author = data.kontentItemAuthor
   const menu = data.kontentItemMenu
   const copyright = data.kontentItemSiteMetadata.elements.copyright.value
-  const isHomePage = get(data, 'pathname', '/') === '/'
   const profilePic = data.kontentItemAuthor.elements.avatar_image.value[0].url
 
   return (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -23,7 +23,7 @@ class IndexRoute extends React.Component {
             <title>{title}</title>
             <meta name="description" content={subtitle} />
           </Helmet>
-          <Sidebar />
+          <Sidebar isHomePage />
           <div className="content">
             <div className="content__inner">{items}</div>
           </div>


### PR DESCRIPTION
### Motivation

The sidebar is set up to render the title as H1 on the home page and H2 elsewhere. Currently the boolean const isHomePage assignment tries to use the pathname from data but this is not present so it is always evaluated as true.

I have switched to the approach taken on the original gatsby-starter-lumen project and made it a prop for the sidebar which is only set as true on IndexRoute.

### How to test

Navigate to "About me" page, inspect author title and verify now showing as H2 as intended.
